### PR TITLE
fix: avoid Project redirect EEXIST on Vercel

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,8 +50,9 @@ const config = {
       {
         redirects: [
           {
-            to: '/docs/project/cpp-project-ideas',
-            from: ['/docs/project/Project', '/docs/project/Project/'],
+            // trailingSlash:true — only one `from` form; both slash variants write the same file and EEXIST on Vercel
+            to: '/docs/project/cpp-project-ideas/',
+            from: '/docs/project/Project/',
           },
           { to: '/docs/c++/advanced/', from: ['/docs/c++/advance/', '/docs/c++/advance/index', '/docs/c++/advance/intro'] },
           {


### PR DESCRIPTION
## Summary
- Vercel failed with `EEXIST` writing `build/docs/project/Project/index.html`.
- Cause: client-redirects listed both `/docs/project/Project` and `/docs/project/Project/` with `trailingSlash: true`.
- Keep a single `from`: `/docs/project/Project/` → `/docs/project/cpp-project-ideas/`.

## Test plan
- [ ] Vercel build passes past redirect generation
- [ ] `/docs/project/Project/` redirects to cpp-project-ideas


Made with [Cursor](https://cursor.com)