### PR TITLE
docs: add GPU Platforms tracks (Android, CUDA, ROCm, Mac, Vulkan)

### DIFF
--- a/docs/gpu/index.mdx
+++ b/docs/gpu/index.mdx
@@ -39,6 +39,11 @@ This section connects parallel hardware, GPU execution models, OpenCL, and compi
 
 <div style={{display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', marginBottom: '1.5rem'}}>
   <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)', background: 'var(--ifm-background-surface-color)'}}>
+    <h3 style={{marginTop: 0}}>Platforms</h3>
+    <p>Android, CUDA, ROCm, Mac, Vulkan — pick the stack for your hardware.</p>
+    <Link to="/docs/gpu/platforms/">Open platforms</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)', background: 'var(--ifm-background-surface-color)'}}>
     <h3 style={{marginTop: 0}}>GPU Compilers Track</h3>
     <p>Use the guided GPU compiler path instead of jumping between pages.</p>
     <Link to="/docs/tracks/gpu-compilers">Open track</Link>
@@ -59,6 +64,7 @@ This section connects parallel hardware, GPU execution models, OpenCL, and compi
 
 ## Core Articles
 
+- [GPU Platforms](/docs/gpu/platforms/) — Android · CUDA · ROCm · Mac · Vulkan
 - [GPU Introduction](/docs/The_Graphic_Rendering_Pipeline)
 - [What Is GPU?](/docs/gpu/what_is_gpu)
 - [CPU vs GPU](/docs/gpu/CPU_Vs_GPU)

--- a/docs/gpu/platforms/android/index.md
+++ b/docs/gpu/platforms/android/index.md
@@ -1,0 +1,49 @@
+---
+title: Android GPU Track
+description: Learn parallel / GPGPU programming on Android phone GPUs (Adreno, Mali) with OpenCL detection and Vulkan compute.
+keywords:
+  - Android GPU programming
+  - phone GPU parallel programming
+  - Adreno OpenCL
+  - Mali GPU compute
+  - Vulkan compute Android
+  - learn GPGPU on smartphone
+---
+
+import Link from '@docusaurus/Link';
+import AdBanner from '@site/src/components/AdBanner';
+
+# Android GPU Track
+
+Use the GPU in your phone to learn **data-parallel** programming: kernels, work-items, workgroups, memory traffic, and honest timing — without a desktop GPU.
+
+<AdBanner />
+
+## Start here
+
+1. [Learn parallel programming on your phone GPU](/docs/gpu/platforms/android/learn-parallel-on-phone) — full learning path  
+2. [Detect OpenCL on Android](/docs/gpu/opencl/basic/detecting_opencl_gpu_on_android) — first on-device check  
+3. [OpenCL for Android hub](/docs/gpu/opencl/openclforandroid)
+
+## Stack reality on phones
+
+| API | Role on Android |
+|-----|-----------------|
+| **Vulkan compute** | Most portable long-term path |
+| **OpenCL** | Available on many Adreno/Mali devices via vendor `libOpenCL.so` — detect first |
+| **CUDA** | Not on phones |
+
+## Coming next on this track
+
+- First OpenCL kernel on Android (vector add)  
+- Vulkan compute hello-dispatch APK  
+- Measuring GPU time (warmup, median, thermal)  
+- Adreno vs Mali beginner checklist  
+
+## External references
+
+- [Vulkan: Compute on Android](https://docs.vulkan.org/tutorial/latest/Advanced_Vulkan_Compute/12_Mobile_and_Embedded_Compute/02_android_compute.html)  
+- [Android: RenderScript → Vulkan](https://developer.android.com/guide/topics/renderscript/migrate/migrate-vulkan)  
+- [Arm OpenCL programming guide (PDF)](https://developer.arm.com/-/media/developer/Graphics%20and%20Multimedia/Developer%20Guides%20-%20PDFs/Arm%20Guide%20to%20OpenCL%20Programming.pdf)
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docs/gpu/platforms/android/learn-parallel-on-phone.md
+++ b/docs/gpu/platforms/android/learn-parallel-on-phone.md
@@ -1,0 +1,75 @@
+---
+title: Learn Parallel Programming on Your Phone GPU
+description: Step-by-step path to learn data-parallel programming using an Android phone GPU — fundamentals, OpenCL detection, Vulkan compute, and mobile caveats.
+keywords:
+  - learn parallel programming on phone
+  - Android phone GPU tutorial
+  - mobile GPGPU learning path
+  - OpenCL Android beginner
+  - Vulkan compute phone
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# Learn Parallel Programming on Your Phone GPU
+
+You do not need a desktop NVIDIA card to start. Android phones (Adreno / Mali) can run the same **data-parallel** ideas as CUDA courses: kernels, workgroups, memory, speedup — on hardware you already own.
+
+This is a **path**, not a full course dump.
+
+<AdBanner />
+
+## Path (in order)
+
+### 1. Fundamentals
+
+1. [What is Parallel Computing?](/docs/parallel-computing/fundamentals/what-is-parallel-computing)  
+2. [Program, Process, Thread, Core](/docs/parallel-computing/fundamentals/program-process-thread-core)  
+3. [Amdahl's and Gustafson's Laws](/docs/parallel-computing/fundamentals/amdahls-and-gustafsons-law)  
+4. [Measuring Parallel Performance](/docs/parallel-computing/fundamentals/measuring-parallel-performance)
+
+### 2. GPU mental model
+
+1. [What is a GPU?](/docs/gpu/what_is_gpu)  
+2. [What is OpenCL?](/docs/gpu/opencl/basic/what_is_opencl)
+
+| Concept | On a phone GPU |
+|--------|----------------|
+| Work-item | One kernel invocation |
+| Workgroup | Threads that can share local memory |
+| Global memory | Device DRAM (power + latency cost) |
+| Kernel | Code every work-item runs |
+
+### 3. On-device: detect OpenCL
+
+- [Detecting OpenCL GPU on Android](/docs/gpu/opencl/basic/detecting_opencl_gpu_on_android)
+
+Some phones expose OpenCL; some do not. Detect before writing kernels.
+
+### 4. Portable practice: Vulkan compute
+
+| Resource | Why |
+|----------|-----|
+| [Vulkan Advanced Compute](https://docs.vulkan.org/tutorial/latest/Advanced_Vulkan_Compute/introduction.html) | Parallelism + memory model |
+| [Compute on Android](https://docs.vulkan.org/tutorial/latest/Advanced_Vulkan_Compute/12_Mobile_and_Embedded_Compute/02_android_compute.html) | Phone limits + power |
+| [Android Vulkan chapter](https://docs.vulkan.org/tutorial/latest/14_Android.html) | App bring-up |
+
+**First exercises:** vector add → reduction → blur/histogram → timed runs (median, not one lucky sample).
+
+### 5. Mobile habits
+
+- Thermal throttling is real — short kernels, report median  
+- Query device limits; do not assume desktop sizes  
+- Mark truly constant SSBO params `readonly` when applicable  
+
+## Weekly plan
+
+| Week | Goal |
+|------|------|
+| 1 | Fundamentals + GPU mental model |
+| 2 | NDK/ADB + OpenCL detection |
+| 3 | First kernel (OpenCL or Vulkan) |
+| 4 | One real kernel + honest timing |
+| 5 | CPU vs GPU on the same phone |
+
+Part of the [Android GPU Track](/docs/gpu/platforms/android) · [All platforms](/docs/gpu/platforms/)

--- a/docs/gpu/platforms/cuda.md
+++ b/docs/gpu/platforms/cuda.md
@@ -1,0 +1,35 @@
+---
+title: CUDA Track (NVIDIA)
+description: CompilerSutra CUDA / NVIDIA GPU programming track — setup, kernels, memory, and profiling roadmap.
+keywords:
+  - CUDA tutorial
+  - NVIDIA GPU programming
+  - learn CUDA
+  - CUDA vs OpenCL
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# CUDA Track (NVIDIA)
+
+Desktop and datacenter path for **NVIDIA GPUs**. Best when you have a GeForce / RTX / datacenter card.
+
+<AdBanner />
+
+## Status
+
+Track scaffold — articles will land here. Meanwhile:
+
+- Related OpenCL-on-NVIDIA notes: [OpenCL NVIDIA hub](/docs/gpu/opencl/nvidia)  
+- Shared concepts: [What is a GPU?](/docs/gpu/what_is_gpu) · [Parallel Computing](/docs/parallel-computing/)
+
+## Planned modules
+
+1. Install CUDA toolkit + verify `nvidia-smi`  
+2. First kernel (vector add)  
+3. Grid / block / thread and occupancy  
+4. Global / shared / constant memory  
+5. Profiling with Nsight (`nsys` / `ncu`)  
+6. Common pitfalls (divergency, uncoalesced loads)
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docs/gpu/platforms/index.md
+++ b/docs/gpu/platforms/index.md
@@ -1,0 +1,71 @@
+---
+title: GPU Platforms
+description: Pick your GPU stack — Android phone GPUs, CUDA, ROCm, Mac/Metal, Vulkan, and more. CompilerSutra GPU tutorial tracks by platform.
+slug: /gpu/platforms/
+keywords:
+  - GPU platforms
+  - CUDA tutorial
+  - ROCm tutorial
+  - Android GPU programming
+  - Mac Metal GPU
+  - Vulkan compute
+  - learn GPU programming by platform
+---
+
+import Link from '@docusaurus/Link';
+import AdBanner from '@site/src/components/AdBanner';
+
+# GPU Platforms
+
+Same parallel ideas (kernels, workgroups, memory) — different stacks per machine.  
+Pick the track that matches **the hardware you have**, then follow that path.
+
+<AdBanner />
+
+## Tracks
+
+<div style={{display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', marginBottom: '1.5rem'}}>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>Android</h3>
+    <p>Phone GPUs (Adreno / Mali). OpenCL detect + Vulkan compute.</p>
+    <Link to="/docs/gpu/platforms/android/">Open Android track</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>CUDA (NVIDIA)</h3>
+    <p>Desktop / datacenter NVIDIA GPUs. Classic GPGPU path.</p>
+    <Link to="/docs/gpu/platforms/cuda">Open CUDA track</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>ROCm (AMD)</h3>
+    <p>AMD GPUs with HIP / ROCm tooling and OpenCL on AMDGPU.</p>
+    <Link to="/docs/gpu/platforms/rocm">Open ROCm track</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>Mac</h3>
+    <p>Apple Silicon — Metal, and what still works for OpenCL/Vulkan.</p>
+    <Link to="/docs/gpu/platforms/mac">Open Mac track</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>Vulkan</h3>
+    <p>Cross-vendor compute (desktop + Android). SPIR-V pipelines.</p>
+    <Link to="/docs/gpu/platforms/vulkan">Open Vulkan track</Link>
+  </div>
+  <div style={{padding: '1rem', borderRadius: '18px', border: '1px solid var(--ifm-color-emphasis-200)'}}>
+    <h3 style={{marginTop: 0}}>Other</h3>
+    <p>Intel / oneAPI, SYCL, and stacks we add next.</p>
+    <Link to="/docs/gpu/platforms/other">Open other platforms</Link>
+  </div>
+</div>
+
+## Shared foundations (all platforms)
+
+- [What is a GPU?](/docs/gpu/what_is_gpu)
+- [CPU vs GPU](/docs/gpu/CPU_Vs_GPU)
+- [Intro to Parallel Programming](/docs/gpu/Parallel_Programming/Intro_to_Parallel_Programming)
+- [Parallel Computing curriculum](/docs/parallel-computing/)
+- [GPU Programming TOC](/docs/gpu/gpu_programming/gpu_programming_toc)
+
+## Related OpenCL hubs (already on site)
+
+- [OpenCL Master](/docs/gpu/opencl/opencl)
+- [AMDGPU](/docs/gpu/opencl/amdgpu) · [AMD CPU](/docs/gpu/opencl/amdcpu) · [NVIDIA](/docs/gpu/opencl/nvidia) · [Android](/docs/gpu/opencl/openclforandroid)

--- a/docs/gpu/platforms/mac.md
+++ b/docs/gpu/platforms/mac.md
@@ -1,0 +1,31 @@
+---
+title: Mac GPU Track
+description: GPU programming on Apple Silicon — Metal compute, and what still works for OpenCL and Vulkan on Mac.
+keywords:
+  - Mac GPU programming
+  - Apple Silicon Metal
+  - Metal compute tutorial
+  - OpenCL on Mac
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# Mac GPU Track
+
+Apple Silicon path. Primary API today: **Metal** (compute + graphics). OpenCL is deprecated on Apple platforms; plan Metal-first.
+
+<AdBanner />
+
+## Status
+
+Track scaffold — Metal compute articles coming.
+
+## Planned modules
+
+1. Xcode / Metal setup on Apple Silicon  
+2. First compute kernel (MPS / Metal Shading Language)  
+3. Buffers, textures, threadgroups  
+4. Timing and Instruments  
+5. Portability notes (Metal vs Vulkan vs CUDA)
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docs/gpu/platforms/other.md
+++ b/docs/gpu/platforms/other.md
@@ -1,0 +1,28 @@
+---
+title: Other GPU Platforms
+description: Intel / oneAPI, SYCL, and other GPU stacks on the CompilerSutra roadmap.
+keywords:
+  - oneAPI GPU
+  - SYCL tutorial
+  - Intel GPU programming
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# Other GPU Platforms
+
+Stacks we will expand next.
+
+<AdBanner />
+
+## Planned
+
+| Platform | Focus |
+|----------|--------|
+| **Intel / oneAPI** | Level Zero, SYCL, OpenCL on Intel GPUs |
+| **SYCL** | Single-source C++ across vendors |
+| **iOS** | Metal (ties to [Mac track](/docs/gpu/platforms/mac)) |
+
+Have a stack you want first? Say which hardware you use.
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docs/gpu/platforms/rocm.md
+++ b/docs/gpu/platforms/rocm.md
@@ -1,0 +1,35 @@
+---
+title: ROCm Track (AMD)
+description: CompilerSutra ROCm / AMDGPU track — HIP, ROCm tools, and OpenCL on AMD GPUs.
+keywords:
+  - ROCm tutorial
+  - AMD GPU programming
+  - HIP tutorial
+  - OpenCL AMDGPU
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# ROCm Track (AMD)
+
+AMD GPU path: **ROCm**, **HIP**, and OpenCL on **AMDGPU**.
+
+<AdBanner />
+
+## Status
+
+Track scaffold. Existing OpenCL-on-AMD content:
+
+- [AMDGPU OpenCL Master](/docs/gpu/opencl/amdgpu)  
+- [Getting started with OpenCL on AMDGPU](/docs/gpu/opencl/basic/getting_started_with_opencl_on_amdgpu)  
+- [Setting up OpenCL](/docs/gpu/opencl/basic/setting_up_opencl)
+
+## Planned modules
+
+1. ROCm install + `rocminfo`  
+2. HIP hello world (and CUDA→HIP notes)  
+3. OpenCL on AMDGPU validation  
+4. Profiling with `rocprof`  
+5. Memory and wavefront basics on RDNA/CDNA
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docs/gpu/platforms/vulkan.md
+++ b/docs/gpu/platforms/vulkan.md
@@ -1,0 +1,36 @@
+---
+title: Vulkan Compute Track
+description: Cross-vendor GPU compute with Vulkan and SPIR-V — desktop and Android.
+keywords:
+  - Vulkan compute tutorial
+  - SPIR-V compute
+  - GPGPU Vulkan
+  - Vulkan Android compute
+---
+
+import AdBanner from '@site/src/components/AdBanner';
+
+# Vulkan Compute Track
+
+Cross-vendor compute API. Same mental model on **desktop and Android**.
+
+<AdBanner />
+
+## Status
+
+Track scaffold. Strong external start:
+
+- [Vulkan Advanced Compute](https://docs.vulkan.org/tutorial/latest/Advanced_Vulkan_Compute/introduction.html)  
+- [Compute on Android](https://docs.vulkan.org/tutorial/latest/Advanced_Vulkan_Compute/12_Mobile_and_Embedded_Compute/02_android_compute.html)
+
+Phone-oriented path: [Android track](/docs/gpu/platforms/android)
+
+## Planned modules
+
+1. Instance / device / queue for compute  
+2. SPIR-V from GLSL (or Slang)  
+3. Descriptor sets + `vkCmdDispatch`  
+4. Barriers and readback  
+5. Subgroups and mobile limits
+
+Back to [GPU Platforms](/docs/gpu/platforms/).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,9 +49,10 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
+          // Old capital-P URL used in footers/side links → projects catalogue
           {
-            to: '/docs/project/cpp-project-ideas',
-            from: ['/docs/project/Project', '/docs/project/Project/'],
+            to: '/docs/project/',
+            from: '/docs/Project',
           },
           { to: '/docs/c++/advanced/', from: ['/docs/c++/advance/', '/docs/c++/advance/index', '/docs/c++/advance/intro'] },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,16 +49,10 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
-          // Old capital-P URL used in footers/side links → projects catalogue
           {
-<<<<<<< HEAD
             // trailingSlash:true — only one `from` form; both slash variants write the same file and EEXIST on Vercel
             to: '/docs/project/cpp-project-ideas/',
             from: '/docs/project/Project/',
-=======
-            to: '/docs/project/',
-            from: '/docs/Project',
->>>>>>> pr-478
           },
           { to: '/docs/c++/advanced/', from: ['/docs/c++/advance/', '/docs/c++/advance/index', '/docs/c++/advance/intro'] },
           {

--- a/sidebars/tutorials.js
+++ b/sidebars/tutorials.js
@@ -214,6 +214,37 @@ const tutorials = {
         'gpu/what_is_gpu',
       ],
     },
+    {
+      type: 'category',
+      label: 'Platforms',
+      collapsed: false,
+      link: {
+        type: 'doc',
+        id: 'gpu/platforms/index',
+      },
+      items: [
+        'gpu/platforms/index',
+        {
+          type: 'category',
+          label: 'Android',
+          collapsed: false,
+          link: {
+            type: 'doc',
+            id: 'gpu/platforms/android/index',
+          },
+          items: [
+            'gpu/platforms/android/index',
+            'gpu/platforms/android/learn-parallel-on-phone',
+            'gpu/opencl/basic/detecting_opencl_gpu_on_android',
+          ],
+        },
+        'gpu/platforms/cuda',
+        'gpu/platforms/rocm',
+        'gpu/platforms/mac',
+        'gpu/platforms/vulkan',
+        'gpu/platforms/other',
+      ],
+    },
   ],
 
   llvmTutorialSidebar: [


### PR DESCRIPTION
## Summary
- Add GPU Platforms hub (Android, CUDA, ROCm, Mac, Vulkan, Other)
- Android track: phone GPU parallel-programming learning path
- Rebased onto current `main` (keeps #477 Project redirect fix; resolves conflict with #478)

Replaces conflicting https://github.com/aabhinavg1/compilersutra/pull/478

## Test plan
- [ ] `npm run build` succeeds
- [ ] `/docs/gpu/platforms/` and Android pages render
- [ ] GPU Tutorials → Platforms sidebar entries show
- [ ] Project redirect from #477 still works (no EEXIST)


Made with [Cursor](https://cursor.com)